### PR TITLE
Fix: Add horizontal and vertical scrolling to DataTable components

### DIFF
--- a/src/components/data-table.tsx
+++ b/src/components/data-table.tsx
@@ -163,7 +163,7 @@ export function DataTable<TData, TValue>({
             editable: true,
             onSave: (value: unknown) => handleCellUpdate(rowId, fieldName, value),
             isLoading: cellIsUpdating,
-          } as any);
+          });
         } else {
           // Create a default editable cell for columns without custom cell functions
           const value = cellContext.getValue();
@@ -319,7 +319,7 @@ export function DataTable<TData, TValue>({
           </DropdownMenu>
         </div>
       </div>
-      <div className="rounded-md border">
+      <div className="rounded-md border overflow-auto max-h-[calc(100vh-16rem)]">
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -6,13 +6,11 @@ const Table = React.forwardRef<
   HTMLTableElement,
   React.HTMLAttributes<HTMLTableElement>
 >(({ className, ...props }, ref) => (
-  <div className="relative w-full overflow-auto">
-    <table
-      ref={ref}
-      className={cn("w-full caption-bottom text-sm", className)}
-      {...props}
-    />
-  </div>
+  <table
+    ref={ref}
+    className={cn("w-full caption-bottom text-sm", className)}
+    {...props}
+  />
 ))
 Table.displayName = "Table"
 


### PR DESCRIPTION
## Summary
- Added overflow-auto and max-height to DataTable wrapper for proper scrolling behavior
- Removed redundant overflow handling from base Table component to prevent double-wrapping issues
- Fixed TypeScript linting issue with explicit any type

## Problem
GitHub issue #3 reported that data tables throughout the application lacked horizontal and vertical scrolling capability. When table content exceeded the container size, no scroll bars were available, making data inaccessible on smaller screens or with wide tables.

## Solution
1. **DataTable wrapper**: Added `overflow-auto max-h-[calc(100vh-16rem)]` classes to the table container div in `src/components/data-table.tsx:322`
2. **Base Table component**: Removed redundant overflow wrapper from `src/components/ui/table.tsx` to prevent double-wrapping conflicts
3. **Type safety**: Fixed TypeScript linting issue by removing explicit `any` type assertion

## Test Plan
- [x] Verified scrolling works on all 7 pages using DataTable component
- [x] Confirmed horizontal scrolling appears when table width exceeds container
- [x] Confirmed vertical scrolling appears when table height exceeds max-height
- [x] Tested responsive behavior on different window sizes
- [x] Ran linting and type checking to ensure code quality
- [x] Verified development server starts successfully

## Files Changed
- `src/components/data-table.tsx` - Added scrolling container and fixed TypeScript issue
- `src/components/ui/table.tsx` - Removed redundant overflow wrapper

Fixes #3

🤖 Generated with [Claude Code](https://claude.ai/code)