### PR TITLE
Fix: Replace transparent backgrounds with solid theme-based backgrounds

### DIFF
--- a/src/components/app-chatpanel.tsx
+++ b/src/components/app-chatpanel.tsx
@@ -81,10 +81,11 @@ export default function AppChatPanel({ className }: AppChatPanelProps) {
   return (
     <div
       className={cn(
-        "h-full transition-all duration-300 ease-in-out border-l border-sidebar-border bg-sidebar text-sidebar-foreground",
+        "h-full transition-all duration-300 ease-in-out border-l border-sidebar-border bg-sidebar text-sidebar-foreground backdrop-blur-none",
         isExpanded ? "w-96" : "w-12",
         className
       )}
+      style={{ backgroundColor: 'hsl(var(--sidebar))' }}
     >
       {/* Collapsed state - just the toggle button */}
       {!isExpanded && (

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -222,13 +222,14 @@ const Sidebar = React.forwardRef<
         {/* This is what handles the sidebar gap on desktop */}
         <div
           className={cn(
-            "duration-200 relative h-svh w-[--sidebar-width] bg-transparent transition-[width] ease-linear",
+            "duration-200 relative h-svh w-[--sidebar-width] bg-sidebar transition-[width] ease-linear",
             "group-data-[collapsible=offcanvas]:w-0",
             "group-data-[side=right]:rotate-180",
             variant === "floating" || variant === "inset"
               ? "group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]"
               : "group-data-[collapsible=icon]:w-[--sidebar-width-icon]"
           )}
+          style={{ backgroundColor: 'hsl(var(--sidebar))' }}
         />
         <div
           className={cn(
@@ -247,6 +248,7 @@ const Sidebar = React.forwardRef<
           <div
             data-sidebar="sidebar"
             className="flex h-full w-full flex-col bg-sidebar group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow"
+            style={{ backgroundColor: 'hsl(var(--sidebar))' }}
           >
             {children}
           </div>


### PR DESCRIPTION
## Summary
- Fixed sidebar and chatpanel transparency issues by replacing transparent backgrounds with solid theme-based backgrounds
- Added explicit backgroundColor styles using CSS custom properties to ensure consistent appearance
- Improved visual consistency across light and dark themes

## Problem
GitHub issue #5 reported that both the navbar (sidebar) and chatbar (chatpanel) had transparent backgrounds instead of solid backgrounds based on the current theme. This caused visual inconsistency and poor readability.

## Solution
1. **Sidebar Component**: Changed `bg-transparent` to `bg-sidebar` in the sidebar wrapper div and added explicit `backgroundColor: 'hsl(var(--sidebar))'` style
2. **ChatPanel Component**: Added `backdrop-blur-none` class and explicit `backgroundColor: 'hsl(var(--sidebar))'` style to ensure solid background
3. **Inner Sidebar**: Added explicit background style to the inner sidebar container for double assurance

## Technical Details
- Modified `src/components/ui/sidebar.tsx` to use solid backgrounds instead of transparent
- Modified `src/components/app-chatpanel.tsx` to ensure solid background rendering
- Used CSS custom properties (`hsl(var(--sidebar))`) which automatically adapt to light/dark themes
- Light theme: `--sidebar: 180 6.6667% 97.0588%` (light gray)
- Dark theme: `--sidebar: 228 9.8039% 10%` (dark gray)

## Test Plan
- [x] Verified solid backgrounds appear in both light and dark themes
- [x] Confirmed no transparency issues in sidebar navigation
- [x] Confirmed no transparency issues in chat panel
- [x] Tested theme switching maintains solid backgrounds
- [x] Ran linting and type checking - no new issues introduced
- [x] Verified development server starts successfully

## Files Changed
- `src/components/ui/sidebar.tsx` - Fixed transparent sidebar background
- `src/components/app-chatpanel.tsx` - Fixed transparent chatpanel background

Fixes #5

🤖 Generated with [Claude Code](https://claude.ai/code)